### PR TITLE
Various updates to the homepage stats bar

### DIFF
--- a/src/components/nathanjgill/counter.tsx
+++ b/src/components/nathanjgill/counter.tsx
@@ -1,34 +1,43 @@
 "use client";
 
 import { motion, useMotionValue, useTransform, animate } from "framer-motion";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 
 interface CounterProps {
-  target: number;
-  duration?: number;
-  className?: string;
+    target: number;
+    duration?: number;
+    className?: string;
 }
 
-const Counter: React.FC<CounterProps> = ({ target, duration = 2, className = "text-3xl font-bold"}) => {
-  const count = useMotionValue(0);
-  useTransform(count, (latest) => Math.floor(latest));
-  const [display, setDisplay] = useState(0);
+export default function Counter({ target, duration = 2, className = "text-3xl font-bold"}: CounterProps) {
+    const ref = useRef<HTMLSpanElement>(null);
+    const [width, setWidth] = useState<number>(0);
+    const count = useMotionValue(0);
+    useTransform(count, (latest) => Math.floor(latest));
+    const [display, setDisplay] = useState(0);
 
-  useEffect(() => {
-    const controls = animate(count, target, {
-      duration,
-      ease: "easeOut",
-      onUpdate: (latest) => setDisplay(Math.floor(latest)),
-    });
+    useEffect(() => {
+        if (ref.current) {
+            setWidth(ref.current.offsetWidth);
+        }
 
-    return () => controls.stop();
-  }, [count, target, duration]);
+        const controls = animate(count, target, {
+            duration,
+            ease: "easeOut",
+            onUpdate: (latest) => setDisplay(Math.floor(latest)),
+        });
 
-  return (
-    <motion.span className={className}>
-      {display}
-    </motion.span>
-  );
+        return () => controls.stop();
+    }, [count, target, duration]);
+
+    return (
+        <span style={{ position: "relative", display: "inline-block", width: width ? `${width}px` : undefined, textAlign: "center" }}>
+            <motion.span className={className}>
+                {display}
+            </motion.span>
+            <span ref={ref} style={{ position: "absolute", visibility: "hidden", whiteSpace: "nowrap", pointerEvents: "none", userSelect: "none" }} className={className}>
+                {target}
+            </span>
+        </span>
+    );
 };
-
-export default Counter;

--- a/src/components/nathanjgill/github-about.tsx
+++ b/src/components/nathanjgill/github-about.tsx
@@ -15,7 +15,7 @@ export function GitHubAbout() {
                 <div className="bg-gradient-to-t from-white/100 to-white/0 dark:from-black/100 dark:to-black/0 h-10">
 
                 </div>
-                <div className="bg-black pl-2 pb-2">
+                <div className="bg-white dark:bg-black pl-2 pb-2 w-full">
                     <Link href="/about">
                         <Button variant="ghost">
                             <ArrowRight />

--- a/src/components/nathanjgill/github-about.tsx
+++ b/src/components/nathanjgill/github-about.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 
 export function GitHubAbout() {
     return (
-        <Card className="p-4 max-h-60 overflow-hidden relative flex grow">
+        <Card className="p-4 max-h-60 overflow-hidden relative flex flex-1">
             <div>
                 <h1 className="text-2xl font-semibold">About</h1>
                 <MarkdownRenderer markdownUrl="https://raw.githubusercontent.com/OldUser101/OldUser101/refs/heads/master/README.md"/>
@@ -15,7 +15,7 @@ export function GitHubAbout() {
                 <div className="bg-gradient-to-t from-white/100 to-white/0 dark:from-black/100 dark:to-black/0 h-10">
 
                 </div>
-                <div className="bg-black p-2">
+                <div className="bg-black pl-2 pb-2">
                     <Link href="/about">
                         <Button variant="ghost">
                             <ArrowRight />

--- a/src/components/nathanjgill/github-about.tsx
+++ b/src/components/nathanjgill/github-about.tsx
@@ -1,12 +1,28 @@
 import { Card } from "../ui/card";
 import MarkdownRenderer from "./markdownRenderer";
+import { ArrowRight } from "lucide-react";
+import { Button } from "../ui/button";
+import Link from "next/link";
 
 export function GitHubAbout() {
     return (
-        <Card className="p-4 flex grow">
+        <Card className="p-4 max-h-60 overflow-hidden relative flex grow">
             <div>
                 <h1 className="text-2xl font-semibold">About</h1>
                 <MarkdownRenderer markdownUrl="https://raw.githubusercontent.com/OldUser101/OldUser101/refs/heads/master/README.md"/>
+            </div>
+            <div className="absolute bottom-0 left-0 w-full">
+                <div className="bg-gradient-to-t from-white/100 to-white/0 dark:from-black/100 dark:to-black/0 h-10">
+
+                </div>
+                <div className="bg-black p-2">
+                    <Link href="/about">
+                        <Button variant="ghost">
+                            <ArrowRight />
+                            Read More
+                        </Button>
+                    </Link>
+                </div>
             </div>
         </Card>
     );

--- a/src/components/nathanjgill/github-about.tsx
+++ b/src/components/nathanjgill/github-about.tsx
@@ -15,9 +15,9 @@ export function GitHubAbout() {
                 <div className="bg-gradient-to-t from-white/100 to-white/0 dark:from-black/100 dark:to-black/0 h-10">
 
                 </div>
-                <div className="bg-white dark:bg-black pl-2 pb-2 w-full">
-                    <Link href="/about">
-                        <Button variant="ghost">
+                <div className="bg-white dark:bg-black px-2 pb-2 w-full">
+                    <Link href="/about" className="w-full">
+                        <Button variant="ghost" className="w-full lg:w-auto">
                             <ArrowRight />
                             Read More
                         </Button>

--- a/src/components/nathanjgill/github-stats.tsx
+++ b/src/components/nathanjgill/github-stats.tsx
@@ -8,7 +8,7 @@ interface GitHubStatsCardProps {
 
 export function GitHubStatsCard({ stats }: GitHubStatsCardProps) {
     return (
-        <Card className="flex flex-col md:flex-row gap-4 p-4">
+        <Card className="flex flex-none flex-col md:flex-row gap-4 p-4">
             <div>
                 {
                     // eslint-disable-next-line @next/next/no-img-element

--- a/src/components/nathanjgill/github-toplang.tsx
+++ b/src/components/nathanjgill/github-toplang.tsx
@@ -9,7 +9,7 @@ interface GitHubTopLangProps {
 
 export function GitHubTopLang({ stats }: GitHubTopLangProps) {
     return (
-        <Card className="p-4 flex flex-col">
+        <Card className="p-4 flex flex-col flex-none">
             <h1 className="text-2xl font-semibold mb-2">Top Languages</h1>
             <div className="ml-4 text-lg flex flex-col h-full grow">
                 {stats.topLanguages?.slice(0, 5).map((language: Language) => (

--- a/src/components/nathanjgill/numericStat.tsx
+++ b/src/components/nathanjgill/numericStat.tsx
@@ -12,7 +12,7 @@ export function NumericStat({title, value, suffix, prefix, className}: NumericSt
     return (
         <div className={`flex ${className}`}>
             <p className="text-base font-light mr-2 mt-auto">{prefix}</p>
-            <p className="text-base font-semibold self-end"><Counter target={value}/>{suffix}</p>
+            <div className="text-base font-semibold self-end"><Counter target={value}/>{suffix}</div>
             <p className="text-base font-light ml-2 mt-auto">{title}</p>
         </div>
     );


### PR DESCRIPTION
Various updates to the homepage stats bar, including:
- "Read More" button in the about section to stop excessive text overflow.
- Better flex layout to ensure the GitHub stats and top languages card don't wrap.
- Determine the final size of counters early to stop jitter as they count up. 